### PR TITLE
Restricting FFI permission for improved security

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -5,8 +5,8 @@ libs = ["lib"]
 fs_permissions = [
     { access = "read", path = "./images/" },
     { access = "read", path = "./broadcast" },
+    { access = "read", path = "./lib/forge-devops" }
 ]
-ffi = true
 
 remappings = ['@openzeppelin/contracts=lib/openzeppelin-contracts/contracts']
 


### PR DESCRIPTION
Configures Forge to only allow read access to the `forge-devops` library, reducing the attack surface. This change removes broad filesystem access while retaining necessary permissions for script execution.